### PR TITLE
add list meta types  and disable pretty print response

### DIFF
--- a/apis/meta/v1alpha1/listmeta_types.go
+++ b/apis/meta/v1alpha1/listmeta_types.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListMeta extension of the metav1.ListMeta with paging related data
+type ListMeta struct {
+	metav1.ListMeta `json:",inline"`
+
+	// TotalItems returned in the list
+	TotalItems int `json:"totalItems"`
+
+	// Current page number
+	// +optional
+	Page *int `json:"page,omitempty"`
+
+	// Current items per page
+	// +optional
+	ItemsPerPage *int `json:"itemsPerPage,omitempty"`
+
+	// Total number of pages
+	// +optional
+	TotalPages *int `json:"totalPages,omitempty"`
+}
+
+// ListOptions options for list
+type ListOptions struct {
+
+	// ItemsPerPage desired number of items to be returned in each page
+	ItemsPerPage int `json:"itemsPerPage"`
+
+	// Page desired to be returned
+	Page int `json:"page"`
+}

--- a/errors/errorhandling.go
+++ b/errors/errorhandling.go
@@ -87,6 +87,11 @@ func AsStatusError(response *resty.Response, grs ...schema.GroupResource) error 
 		statusError.ErrStatus.Reason = status.Reason
 	}
 
+	// if the response is a metav1.status use it's reason directly
+	if s, ok := response.Error().(*metav1.Status); ok {
+		statusError.ErrStatus = *s
+	}
+
 	if err, ok := response.Error().(error); ok {
 		if originalErr := err.Error(); originalErr != "" {
 			statusError.ErrStatus.Message = originalErr

--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -515,6 +515,16 @@ func (a *AppBuilder) Filters(filters ...restful.FilterFunction) *AppBuilder {
 	return a
 }
 
+// BuiltInFilters returns built-in filters for webservices
+func (a *AppBuilder) BuiltInFilters() []restful.FilterFunction {
+	return []restful.FilterFunction{disablePrettyPrintFilter}
+}
+
+func disablePrettyPrintFilter(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
+	response.PrettyPrint(false)
+	chain.ProcessFilter(request, response)
+}
+
 // Container adds a containers
 func (a *AppBuilder) Container(container *restful.Container) *AppBuilder {
 	a.container = container

--- a/sharedmain/app_test.go
+++ b/sharedmain/app_test.go
@@ -17,14 +17,55 @@ limitations under the License.
 package sharedmain
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/AlaudaDevops/pkg/fieldindexer"
+	"github.com/emicklei/go-restful/v3"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var _ = Describe("AppBuilder", func() {
+	var (
+		appBuilder *AppBuilder
+	)
+
+	BeforeEach(func() {
+		appBuilder = &AppBuilder{}
+	})
+
+	Context("BuiltInFilters", func() {
+		It("should return filter that disables pretty print", func() {
+
+			filters := appBuilder.BuiltInFilters()
+			Expect(filters).To(HaveLen(1))
+
+			req := restful.NewRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+			recorder := httptest.NewRecorder()
+			resp := restful.NewResponse(recorder)
+			chain := &restful.FilterChain{
+				Filters: []restful.FilterFunction{},
+				Target: func(req *restful.Request, resp *restful.Response) {
+					resp.ResponseWriter.Write([]byte("test"))
+				},
+			}
+
+			filters[0](req, resp, chain)
+
+			respValue := reflect.ValueOf(resp).Elem()
+			prettyPrintField := respValue.FieldByName("prettyPrint")
+
+			Expect(prettyPrintField.Bool()).To(BeFalse())
+			Expect(recorder.Body.String()).To(Equal("test"))
+		})
+	})
+})
 
 func TestAppWithFieldIndexer(t *testing.T) {
 	t.Run("append one field indexer ", func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

1. add list meta types
2. add built-in filter for webservices, you should invoked in your apps. Now, we use built-in filter to disable pretty print response.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
feature: add built-in filter for webservice, you could use Filters(app.BuiltInFilters()...) to enable it,  in  built-in filters, it will disable restfull.response.prettyPrint
```