### PR TITLE
add TypedRateLimiter for use custom baseDelay and maxDelay

### DIFF
--- a/controllers/ratelimit.go
+++ b/controllers/ratelimit.go
@@ -37,8 +37,14 @@ func DefaultRateLimiter() workqueue.RateLimiter {
 // DefaultTypedRateLimiter returns a workqueue rate limiter with a starting value of 2 seconds
 // opposed to controller-runtime's default one of 1 millisecond
 func DefaultTypedRateLimiter[T comparable]() workqueue.TypedRateLimiter[T] {
+	return TypedRateLimiter[T](2*time.Second, 1000*time.Second)
+}
+
+// TypedRateLimiter returns a workqueue rate limiter with value of baseDelay and maxDelay
+// opposed to controller-runtime's default one of 1 millisecond
+func TypedRateLimiter[T comparable](baseDelay time.Duration, maxDelay time.Duration) workqueue.TypedRateLimiter[T] {
 	return workqueue.NewTypedMaxOfRateLimiter(
-		workqueue.NewTypedItemExponentialFailureRateLimiter[T](2*time.Second, 1000*time.Second),
+		workqueue.NewTypedItemExponentialFailureRateLimiter[T](baseDelay, maxDelay),
 		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
 		&workqueue.TypedBucketRateLimiter[T]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

add TypedRateLimiter for use custom baseDelay and maxDelay

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->